### PR TITLE
SH-015 : OpenAI Vision API 동물 분류 요청 API 구현

### DIFF
--- a/src/main/java/com/example/demo/config/openai/OpenAiConfig.java
+++ b/src/main/java/com/example/demo/config/openai/OpenAiConfig.java
@@ -25,7 +25,8 @@ public class OpenAiConfig {
 
     private String apiKey;
     private String apiUrl;
-    private String model;
+    private String model;           // 텍스트 전용 모델 (gpt-4.1-mini)
+    private String visionModel;     // Vision API 전용 모델 (gpt-4o)
 
     @Bean
     public WebClient openAiWebClient() {

--- a/src/main/java/com/example/demo/domain/dto/openai/ChatCompletionResponse.java
+++ b/src/main/java/com/example/demo/domain/dto/openai/ChatCompletionResponse.java
@@ -50,7 +50,16 @@ public class ChatCompletionResponse {
 
     public String getContent() {
         if (choices != null && !choices.isEmpty()) {
-            return choices.get(0).getMessage().getContent();
+            ChatMessage message = choices.get(0).getMessage();
+            Object content = message.getContent();
+
+            // String인 경우 그대로 반환
+            if (content instanceof String) {
+                return (String) content;
+            }
+
+            // getContentAsString() 메서드 사용
+            return message.getContentAsString();
         }
         return null;
     }

--- a/src/main/java/com/example/demo/domain/dto/openai/ChatMessage.java
+++ b/src/main/java/com/example/demo/domain/dto/openai/ChatMessage.java
@@ -5,6 +5,26 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenAI Chat Completion API의 메시지 DTO
+ *
+ * <p>텍스트 전용 또는 Vision API (텍스트 + 이미지) 모두 지원</p>
+ *
+ * <p><b>텍스트 전용 예시:</b></p>
+ * <pre>{@code
+ * ChatMessage.user("고양이에 대해 알려주세요")
+ * }</pre>
+ *
+ * <p><b>Vision API (이미지 포함) 예시:</b></p>
+ * <pre>{@code
+ * ChatMessage.userWithImage("이 동물의 학명을 알려주세요", base64EncodedImage)
+ * }</pre>
+ */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -12,8 +32,17 @@ import lombok.NoArgsConstructor;
 public class ChatMessage {
 
     private String role;
-    private String content;
 
+    /**
+     * 메시지 내용
+     * - 텍스트 전용: String
+     * - Vision API: List<Map<String, Object>> (text + image_url)
+     */
+    private Object content;
+
+    /**
+     * 시스템 메시지 생성 (텍스트 전용)
+     */
     public static ChatMessage system(String content) {
         return ChatMessage.builder()
             .role("system")
@@ -21,6 +50,9 @@ public class ChatMessage {
             .build();
     }
 
+    /**
+     * 사용자 메시지 생성 (텍스트 전용)
+     */
     public static ChatMessage user(String content) {
         return ChatMessage.builder()
             .role("user")
@@ -28,10 +60,56 @@ public class ChatMessage {
             .build();
     }
 
+    /**
+     * 어시스턴트 메시지 생성 (텍스트 전용)
+     */
     public static ChatMessage assistant(String content) {
         return ChatMessage.builder()
             .role("assistant")
             .content(content)
             .build();
+    }
+
+    /**
+     * 사용자 메시지 생성 (Vision API: 텍스트 + 이미지)
+     *
+     * @param text 질문 텍스트
+     * @param base64Image Base64로 인코딩된 이미지 (data:image/jpeg;base64,... 형식)
+     * @return Vision API용 ChatMessage
+     */
+    public static ChatMessage userWithImage(String text, String base64Image) {
+        List<Map<String, Object>> contentParts = new ArrayList<>();
+
+        // 1. 텍스트 파트
+        Map<String, Object> textPart = new HashMap<>();
+        textPart.put("type", "text");
+        textPart.put("text", text);
+        contentParts.add(textPart);
+
+        // 2. 이미지 파트
+        Map<String, Object> imagePart = new HashMap<>();
+        imagePart.put("type", "image_url");
+
+        Map<String, String> imageUrl = new HashMap<>();
+        imageUrl.put("url", base64Image);
+        imagePart.put("image_url", imageUrl);
+
+        contentParts.add(imagePart);
+
+        return ChatMessage.builder()
+            .role("user")
+            .content(contentParts)
+            .build();
+    }
+
+    /**
+     * content를 String으로 반환 (텍스트 전용 메시지인 경우)
+     * Vision API 응답 파싱 시 사용
+     */
+    public String getContentAsString() {
+        if (content instanceof String) {
+            return (String) content;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/example/demo/domain/dto/request/AnimalRecognitionRequest.java
+++ b/src/main/java/com/example/demo/domain/dto/request/AnimalRecognitionRequest.java
@@ -1,0 +1,31 @@
+package com.example.demo.domain.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimalRecognitionRequest {
+
+    @NotNull(message = "이미지 파일은 필수입니다")
+    private MultipartFile image;
+
+    private Float confidenceThreshold;
+    private Integer maxResults;
+    private Boolean includeSpeciesInfo;
+
+    public static AnimalRecognitionRequest of(MultipartFile image) {
+        return AnimalRecognitionRequest.builder()
+            .image(image)
+            .confidenceThreshold(0.5f)
+            .maxResults(10)
+            .includeSpeciesInfo(true)
+            .build();
+    }
+}

--- a/src/main/java/com/example/demo/domain/dto/response/AnimalRecognitionResponse.java
+++ b/src/main/java/com/example/demo/domain/dto/response/AnimalRecognitionResponse.java
@@ -1,0 +1,37 @@
+package com.example.demo.domain.dto.response;
+
+import com.example.demo.domain.dto.vision.AnimalDetection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimalRecognitionResponse {
+
+    private String imageFileName;
+    private List<AnimalDetection> detections;
+    private Integer totalDetections;
+    private Float averageConfidence;
+    private LocalDateTime timestamp;
+
+    public static AnimalRecognitionResponse of(String imageFileName, List<AnimalDetection> detections) {
+        Float avgConfidence = detections.stream()
+            .map(AnimalDetection::getConfidence)
+            .reduce(0.0f, Float::sum) / detections.size();
+
+        return AnimalRecognitionResponse.builder()
+            .imageFileName(imageFileName)
+            .detections(detections)
+            .totalDetections(detections.size())
+            .averageConfidence(avgConfidence)
+            .timestamp(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/main/java/com/example/demo/domain/dto/vision/AnimalDetection.java
+++ b/src/main/java/com/example/demo/domain/dto/vision/AnimalDetection.java
@@ -1,0 +1,55 @@
+package com.example.demo.domain.dto.vision;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimalDetection {
+
+    private String label;              // 일반 명칭 (예: "Cat", "Dog", "Bengal Cat")
+    private Float confidence;          // 신뢰도 (0.0 ~ 1.0)
+    private String description;        // 설명
+    private String scientificName;     // 학명 (예: "Felis catus")
+    private BoundingBox boundingBox;   // 이미지 내 위치 정보 (선택 사항)
+
+    public static AnimalDetection of(String label, Float confidence, String description) {
+        return AnimalDetection.builder()
+            .label(label)
+            .confidence(confidence)
+            .description(description)
+            .build();
+    }
+
+    public static AnimalDetection of(String label, Float confidence, String description, BoundingBox boundingBox) {
+        return AnimalDetection.builder()
+            .label(label)
+            .confidence(confidence)
+            .description(description)
+            .boundingBox(boundingBox)
+            .build();
+    }
+
+    public static AnimalDetection of(String label, Float confidence, String description, String scientificName) {
+        return AnimalDetection.builder()
+            .label(label)
+            .confidence(confidence)
+            .description(description)
+            .scientificName(scientificName)
+            .build();
+    }
+
+    public static AnimalDetection of(String label, Float confidence, String description, String scientificName, BoundingBox boundingBox) {
+        return AnimalDetection.builder()
+            .label(label)
+            .confidence(confidence)
+            .description(description)
+            .scientificName(scientificName)
+            .boundingBox(boundingBox)
+            .build();
+    }
+}

--- a/src/main/java/com/example/demo/domain/dto/vision/BoundingBox.java
+++ b/src/main/java/com/example/demo/domain/dto/vision/BoundingBox.java
@@ -1,0 +1,31 @@
+package com.example.demo.domain.dto.vision;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoundingBox {
+
+    private Integer x1;
+    private Integer y1;
+    private Integer x2;
+    private Integer y2;
+    private Integer width;
+    private Integer height;
+
+    public static BoundingBox of(Integer x1, Integer y1, Integer x2, Integer y2) {
+        return BoundingBox.builder()
+            .x1(x1)
+            .y1(y1)
+            .x2(x2)
+            .y2(y2)
+            .width(x2 - x1)
+            .height(y2 - y1)
+            .build();
+    }
+}

--- a/src/main/java/com/example/demo/domain/service/AnimalVisionService.java
+++ b/src/main/java/com/example/demo/domain/service/AnimalVisionService.java
@@ -1,0 +1,155 @@
+package com.example.demo.domain.service;
+
+import com.example.demo.domain.dto.vision.AnimalDetection;
+import com.example.demo.exceptions.errorcode.AiErrorCode;
+import com.example.demo.exceptions.exception.AiException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OpenAI GPT-4o Vision API를 사용한 동물 인식 서비스
+ *
+ * <p>이미지에서 동물을 인식하고 정확한 학명을 분류합니다.</p>
+ *
+ * <p><b>주요 기능:</b></p>
+ * <ul>
+ *   <li>이미지에서 여러 동물을 동시에 인식</li>
+ *   <li>동물의 정확한 학명 반환</li>
+ *   <li>신뢰도 기반 필터링</li>
+ *   <li>구체적인 종 구분 (예: Bengal Cat vs Persian Cat)</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnimalVisionService {
+
+    private final OpenAiService openAiService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * OpenAI GPT-4o Vision API를 사용하여 이미지에서 여러 동물을 인식하고 학명을 반환합니다.
+     *
+     * <p><b>동작 원리:</b></p>
+     * <ol>
+     *   <li>이미지를 Base64로 인코딩</li>
+     *   <li>GPT-4o Vision API에 이미지 전송 (maxResults 전달)</li>
+     *   <li>응답받은 JSON 배열 파싱 (animals: [{ label, scientificName, confidence }, ...])</li>
+     *   <li>신뢰도 임계값 적용하여 필터링</li>
+     * </ol>
+     *
+     * <p><b>GPT-4o Vision API 특징:</b></p>
+     * <ul>
+     *   <li>이미지를 직접 분석하여 정확한 종 구분 (예: Bengal Cat vs Persian Cat)</li>
+     *   <li>학명을 바로 반환 (1회 API 호출로 완료)</li>
+     *   <li>여러 동물을 동시에 인식 가능</li>
+     *   <li>높은 정확도와 신뢰도</li>
+     * </ul>
+     *
+     * @param imageFile 분석할 이미지 파일 (MultipartFile 형식, 최대 10MB)
+     * @param confidenceThreshold 신뢰도 임계값 0.0~1.0 (null이면 기본값 0.5 사용)
+     * @param maxResults 최대 결과 개수 (null이면 기본값 10개)
+     * @return 동물 탐지 결과 리스트 (신뢰도 높은 순으로 정렬)
+     * @throws AiException 이미지 처리 실패 또는 Vision API 오류 발생 시
+     */
+    public List<AnimalDetection> detectAnimals(MultipartFile imageFile, Float confidenceThreshold, Integer maxResults) {
+        log.info("Starting animal detection with GPT-4o Vision for image: {} (maxResults: {})",
+            imageFile.getOriginalFilename(), maxResults);
+
+        try {
+            // 1. 이미지 파일 검증
+            validateImageFile(imageFile);
+
+            // 2. 신뢰도 임계값 설정 (기본값: 0.5)
+            float threshold = confidenceThreshold != null ? confidenceThreshold : 0.5f;
+
+            // 3. maxResults 기본값 설정 (기본값: 10)
+            int maxCount = maxResults != null ? maxResults : 10;
+
+            // 4. OpenAI Vision API 호출 (동기 처리)
+            String jsonResponse = openAiService.analyzeAnimalImage(imageFile, maxCount)
+                .block();  // Mono를 동기적으로 처리
+
+            if (jsonResponse == null || jsonResponse.isEmpty()) {
+                log.warn("Empty response from Vision API");
+                return new ArrayList<>();
+            }
+
+            // 5. JSON 응답 파싱 (배열 처리)
+            JsonNode responseNode = objectMapper.readTree(jsonResponse);
+            JsonNode animalsArray = responseNode.get("animals");
+
+            if (animalsArray == null || !animalsArray.isArray()) {
+                log.warn("Invalid response format: 'animals' array not found");
+                return new ArrayList<>();
+            }
+
+            // 6. 배열을 순회하며 AnimalDetection 리스트 생성
+            List<AnimalDetection> detections = new ArrayList<>();
+            for (JsonNode animalNode : animalsArray) {
+                String label = animalNode.get("label").asText();
+                String scientificName = animalNode.get("scientificName").asText();
+                float confidence = (float) animalNode.get("confidence").asDouble();
+
+                // 7. 신뢰도 임계값 필터링
+                if (confidence >= threshold && !label.equals("해당 없음")) {
+                    AnimalDetection detection = AnimalDetection.of(
+                        label,                    // 일반 명칭 (예: "Bengal Cat")
+                        confidence,               // 신뢰도 (0.0 ~ 1.0)
+                        label,                    // 설명 (label과 동일)
+                        scientificName            // 학명 (예: "Felis catus")
+                    );
+                    detections.add(detection);
+                }
+            }
+
+            log.info("Animal detection completed: {} animals detected (threshold: {})",
+                detections.size(), threshold);
+
+            return detections;
+
+        } catch (Exception e) {
+            log.error("Unexpected error during animal detection: {}", e.getMessage(), e);
+            throw new AiException(AiErrorCode.VISION_API_ERROR);
+        }
+    }
+
+    /**
+     * 이미지 파일 유효성 검증
+     *
+     * <p>검증 항목:</p>
+     * <ul>
+     *   <li>파일이 비어있지 않은지 확인</li>
+     *   <li>파일 형식이 이미지인지 확인 (MIME type)</li>
+     *   <li>파일 크기가 제한(10MB) 이내인지 확인</li>
+     * </ul>
+     *
+     * @param imageFile 검증할 이미지 파일
+     * @throws AiException 파일이 유효하지 않을 경우
+     */
+    private void validateImageFile(MultipartFile imageFile) {
+        if (imageFile == null || imageFile.isEmpty()) {
+            throw new AiException(AiErrorCode.INVALID_IMAGE_FILE);
+        }
+
+        String contentType = imageFile.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new AiException(AiErrorCode.INVALID_IMAGE_FORMAT);
+        }
+
+        // 파일 크기 제한 (10MB)
+        long maxFileSize = 10 * 1024 * 1024; // 10MB in bytes
+        if (imageFile.getSize() > maxFileSize) {
+            throw new AiException(AiErrorCode.IMAGE_FILE_TOO_LARGE);
+        }
+
+        log.debug("Image file validation passed: {} ({})", imageFile.getOriginalFilename(), contentType);
+    }
+}

--- a/src/main/java/com/example/demo/domain/service/OpenAiService.java
+++ b/src/main/java/com/example/demo/domain/service/OpenAiService.java
@@ -239,4 +239,161 @@ public class OpenAiService {
             throw new SpeciesException(SpeciesErrorCode.FAILED_TO_PARSE_OPENAI_RESPONSE);
         }
     }
+
+    /**
+     * 일반 동물 명칭(영문명)을 학명으로 변환합니다.
+     *
+     * <p>Vision API는 일반 명칭(예: "Cat", "Dog")만 반환하므로,
+     * OpenAI를 사용하여 해당 동물의 정확한 학명을 조회합니다.</p>
+     *
+     * <p>동작 방식:</p>
+     * <ol>
+     *   <li>일반 명칭을 OpenAI에 전송</li>
+     *   <li>OpenAI가 해당 동물의 학명을 반환 (예: "Cat" → "Felis catus")</li>
+     *   <li>학명이 존재하지 않거나 불명확한 경우 null 반환</li>
+     * </ol>
+     *
+     * @param commonName 일반 동물 명칭 (예: "Cat", "Dog", "Elephant")
+     * @return 학명 (예: "Felis catus"), 찾을 수 없으면 null
+     */
+    public Mono<String> getScientificNameFromCommonName(String commonName) {
+        log.info("Requesting scientific name for common name: {}", commonName);
+
+        // 입력값 검증
+        if (!StringUtils.hasText(commonName)) {
+            log.warn("Empty common name provided");
+            return Mono.empty();
+        }
+
+        String sanitizedName = commonName.trim();
+
+        // 프롬프트 생성
+        String prompt = String.format("""
+            <동물명>%s</동물명>
+
+            위 동물의 학명(scientific name)을 반환하세요.
+
+            [규칙]
+            1. 학명만 반환하세요 (예: "Felis catus")
+            2. 설명이나 추가 정보 없이 학명만 반환
+            3. 해당 동물이 여러 종을 포함하는 경우, 가장 일반적인 종의 학명 반환
+            4. 동물명이 불명확하거나 존재하지 않는 경우, "해당 없음" 반환
+            """, sanitizedName);
+
+        List<ChatMessage> messages = Arrays.asList(
+            ChatMessage.system("당신은 동물학 전문가입니다. 동물의 일반 명칭을 학명으로 정확하게 변환합니다."),
+            ChatMessage.user(prompt)
+        );
+
+        ChatCompletionRequest request = ChatCompletionRequest.of(
+            openAiConfig.getModel(),
+            messages,
+            null,
+            null
+        );
+
+        return chatCompletion(request)
+            .map(ChatCompletionResponse::getContent)
+            .map(String::trim)
+            .map(scientificName -> {
+                // "해당 없음" 또는 유사한 응답은 null로 처리
+                if (scientificName.equalsIgnoreCase("해당 없음") ||
+                    scientificName.equalsIgnoreCase("없음") ||
+                    scientificName.toLowerCase().contains("not found") ||
+                    scientificName.toLowerCase().contains("unknown")) {
+                    log.info("No scientific name found for: {}", commonName);
+                    return null;
+                }
+                log.info("Scientific name found: {} → {}", commonName, scientificName);
+                return scientificName;
+            })
+            .onErrorResume(error -> {
+                log.error("Failed to get scientific name for {}: {}", commonName, error.getMessage());
+                return Mono.empty();
+            });
+    }
+
+    /**
+     * 이미지를 분석하여 동물들의 학명과 일반 명칭을 배열로 반환합니다. (GPT-4o Vision API)
+     *
+     * <p>동작 방식:</p>
+     * <ol>
+     *   <li>이미지를 Base64로 인코딩</li>
+     *   <li>GPT-4o Vision API에 이미지와 질문 전송</li>
+     *   <li>응답: JSON 배열 형식 { "animals": [{ "label": "...", "scientificName": "...", "confidence": 0.95 }, ...] }</li>
+     * </ol>
+     *
+     * @param imageFile 분석할 이미지 파일
+     * @param maxResults 최대 반환할 동물 개수 (null이면 기본값 10)
+     * @return JSON 문자열 (animals 배열)
+     */
+    public Mono<String> analyzeAnimalImage(org.springframework.web.multipart.MultipartFile imageFile, Integer maxResults) {
+        log.info("Analyzing animal image with GPT-4o Vision API: {} (maxResults: {})",
+            imageFile.getOriginalFilename(), maxResults);
+
+        try {
+            // 1. 이미지를 Base64로 인코딩
+            byte[] imageBytes = imageFile.getBytes();
+            String base64Image = "data:image/jpeg;base64," + java.util.Base64.getEncoder().encodeToString(imageBytes);
+
+            // 2. maxResults 기본값 설정
+            int maxCount = maxResults != null ? maxResults : 10;
+
+            // 3. Vision API 프롬프트 생성
+            String prompt = String.format("""
+                이 이미지에 있는 모든 동물을 분석하여 다음 JSON 형식으로 반환하세요:
+
+                {
+                  "animals": [
+                    {
+                      "label": "동물의 일반 명칭 (영문, 예: Cat, Dog, Bengal Tiger)",
+                      "scientificName": "동물의 학명 (예: Felis catus)",
+                      "confidence": 0.95
+                    },
+                    {
+                      "label": "두 번째 동물",
+                      "scientificName": "두 번째 동물의 학명",
+                      "confidence": 0.88
+                    }
+                  ]
+                }
+
+                [규칙]
+                1. JSON 형식만 반환 (마크다운 코드 블록 없이)
+                2. 이미지에 있는 모든 동물을 배열로 반환 (최대 %d개)
+                3. label은 가능한 한 구체적으로 (예: "Cat"보다 "Bengal Cat" 선호)
+                4. scientificName은 정확한 학명 (속명 + 종명)
+                5. confidence는 인식 신뢰도 (0.0 ~ 1.0)
+                6. 신뢰도가 높은 순서로 정렬
+                7. 동물이 없으면 빈 배열 반환: { "animals": [] }
+                8. 같은 종류의 동물이 여러 마리 있어도 각각 별도 항목으로 반환
+                9. 부분적으로만 보이는 동물도 인식 가능하면 포함
+                """, maxCount);
+
+            // 4. Vision API 메시지 생성
+            List<ChatMessage> messages = Arrays.asList(
+                ChatMessage.system("당신은 동물 인식 전문가입니다. 이미지를 분석하여 모든 동물의 종과 학명을 정확하게 식별합니다."),
+                ChatMessage.userWithImage(prompt, base64Image)
+            );
+
+            // 5. Vision API 요청 (gpt-4o 사용)
+            ChatCompletionRequest request = ChatCompletionRequest.of(
+                openAiConfig.getVisionModel(),  // gpt-4o
+                messages,
+                null,
+                null
+            );
+
+            // 6. API 호출 및 응답 처리
+            return chatCompletion(request)
+                .map(ChatCompletionResponse::getContent)
+                .map(this::cleanJsonResponse)
+                .doOnSuccess(response -> log.info("Vision API analysis completed for: {}", imageFile.getOriginalFilename()))
+                .doOnError(error -> log.error("Vision API analysis failed for {}: {}", imageFile.getOriginalFilename(), error.getMessage()));
+
+        } catch (Exception e) {
+            log.error("Failed to process image file: {}", e.getMessage());
+            return Mono.error(new AiException(AiErrorCode.IMAGE_PROCESSING_ERROR));
+        }
+    }
 }

--- a/src/main/java/com/example/demo/domain/web/AiController.java
+++ b/src/main/java/com/example/demo/domain/web/AiController.java
@@ -3,25 +3,33 @@ package com.example.demo.domain.web;
 import com.example.demo.config.openai.OpenAiConfig;
 import com.example.demo.domain.dto.response.AnimalDescriptionResponse;
 import com.example.demo.domain.service.AiService;
+import com.example.demo.domain.dto.response.AnimalRecognitionResponse;
+import com.example.demo.domain.dto.vision.AnimalDetection;
+import com.example.demo.domain.service.AnimalVisionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/ai")
-@Tag(name = "AI", description = "동물 학명 기반 설명 제공 API")
+@Tag(name = "AI", description = "AI 기반 동물 인식 및 정보 제공 API")
 public class AiController {
 
     private final AiService aiService;
     private final OpenAiConfig openAiConfig;
+    private final AnimalVisionService animalVisionService;
 
     @PostMapping("/animal/description")
     @Operation(
@@ -39,19 +47,41 @@ public class AiController {
         return aiService.getAnimalDescription(scientificName);
     }
 
+    @PostMapping(value = "/animal/recognition", consumes = "multipart/form-data")
+    @Operation(
+        summary = "동물 인식 (GPT-4o Vision)",
+        description = "업로드된 이미지에서 동물을 인식하고 학명을 포함한 종류를 반환합니다. GPT-4o Vision API 사용."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "동물 인식 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (이미지 파일 오류)"),
+        @ApiResponse(responseCode = "500", description = "OpenAI Vision API 호출 실패")
+    })
+    public AnimalRecognitionResponse recognizeAnimals(
+        @RequestParam("image") @NotNull(message = "이미지 파일은 필수입니다") MultipartFile image,
+        @RequestParam(value = "confidenceThreshold", required = false) Float confidenceThreshold,
+        @RequestParam(value = "maxResults", required = false) Integer maxResults
+    ) {
+        List<AnimalDetection> detections = animalVisionService.detectAnimals(image, confidenceThreshold, maxResults);
+        return AnimalRecognitionResponse.of(image.getOriginalFilename(), detections);
+    }
+
     @GetMapping("/config")
     @Operation(
         summary = "AI 설정 정보 조회",
-        description = "현재 OpenAI API 설정 정보를 조회합니다. (API 키는 마스킹됨)"
+        description = "현재 OpenAI API 설정 정보를 조회합니다. (인증 정보는 마스킹됨)"
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "설정 정보 조회 성공")
     })
     public Mono<Object> getConfig() {
         return Mono.just(new Object() {
-            public final String model = openAiConfig.getModel();
-            public final String apiUrl = openAiConfig.getApiUrl();
-            public final String apiKey = maskApiKey(openAiConfig.getApiKey());
+            public final Object openai = new Object() {
+                public final String model = openAiConfig.getModel();
+                public final String visionModel = openAiConfig.getVisionModel();
+                public final String apiUrl = openAiConfig.getApiUrl();
+                public final String apiKey = maskApiKey(openAiConfig.getApiKey());
+            };
         });
     }
 

--- a/src/main/java/com/example/demo/exceptions/errorcode/AiErrorCode.java
+++ b/src/main/java/com/example/demo/exceptions/errorcode/AiErrorCode.java
@@ -9,7 +9,14 @@ public enum AiErrorCode implements ErrorCode {
     EMPTY_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "AI_0004", "OpenAI API에서 빈 응답을 받았습니다"),
     OPENAI_API_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AI_0005", "OpenAI API 키가 유효하지 않습니다"),
     OPENAI_API_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AI_0006", "OpenAI API 사용량 한도를 초과했습니다"),
-    OPENAI_API_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "AI_0007", "OpenAI API 요청 속도 제한에 걸렸습니다");
+    OPENAI_API_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "AI_0007", "OpenAI API 요청 속도 제한에 걸렸습니다"),
+
+    // Vision API 관련 에러 코드 (OpenAI GPT-4o Vision)
+    VISION_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI_0008", "Vision API 호출 중 오류가 발생했습니다"),
+    INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "AI_0009", "유효하지 않은 이미지 파일입니다"),
+    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "AI_0010", "지원하지 않는 이미지 형식입니다"),
+    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "AI_0011", "이미지 파일 크기가 너무 큽니다 (최대 10MB)"),
+    IMAGE_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI_0012", "이미지 처리 중 오류가 발생했습니다");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -31,6 +31,8 @@ spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8
 # openai.api-key is set in application-secret.properties
 openai.api-url=https://api.openai.com/v1
 openai.model=gpt-4.1-mini
+# Vision API용 모델 (이미지 분석 전용)
+openai.vision-model=gpt-4o
 
 # Spring MVC async request timeout (120 seconds = 120000 ms)
 spring.mvc.async.request-timeout=120000


### PR DESCRIPTION
## 개요
- 백엔드에서 LLM Vision API로 요청할 수 있도록 서비스를 구현해야 한다.
## 내용
- OpenAi Vision API 서비스 구현
  - Google Vision API의 경우, cat, dog 정도까지의 분류만 가능하며, 학명을 가져오기는 어려움. 
  - OpenAi Vision API - gpt-4o 모델의 예측도가 생각보다 높게 나옴

